### PR TITLE
Wg client swc

### DIFF
--- a/build_test.txt/build_test.txt
+++ b/build_test.txt/build_test.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/src/builder/flash_lib.rs
+++ b/src/builder/flash_lib.rs
@@ -1,0 +1,135 @@
+use crate::config::settings::load_settings;
+use crate::utils::convert_pathbuf_to_string::Stringify;
+use crate::utils::copy_directory::copy_directory;
+use crate::utils::extract_archive;
+use crate::utils::extract_archive::extract_archive;
+use regex::Regex;
+use std::fs::{create_dir_all, read_dir, remove_dir_all, DirEntry, File};
+use std::io::Write;
+use std::path::PathBuf;
+use tempfile::tempdir;
+use zip::unstable::write::FileOptionsExt;
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("Failed to get game client flash lib: {0}")]
+    LibError(String),
+    #[error("Failed to extract archive: {0}")]
+    ExtractError(#[from] extract_archive::Error),
+    #[error("Failed to build lib: {0}")]
+    BuildError(String),
+    #[error("Value is null: {0}")]
+    NullError(String),
+    #[error("Installation failed: {0}")]
+    InstallationError(String),
+    #[error("Convertion failed: {0}")]
+    PatternError(#[from] regex::Error),
+}
+
+pub struct GameFlashLib {
+    game_flash_lib: PathBuf,
+}
+
+impl From<PathBuf> for GameFlashLib {
+    fn from(value: PathBuf) -> Self {
+        Self {
+            game_flash_lib: value,
+        }
+    }
+}
+
+impl GameFlashLib {
+    fn get_flash_archive_path(
+        &self, game_client_path: &PathBuf, file_identifier: String,
+    ) -> PathBuf {
+        game_client_path
+            .join(format!("res/packages/gui-part{}.pkg", file_identifier))
+    }
+
+    fn is_present(&self) -> bool {
+        self.game_flash_lib.exists()
+    }
+
+    fn build(&self) -> Result<(), Error> {
+        println!("Building game flash lib...");
+        let tmp_dir =
+            tempdir().map_err(|e| Error::BuildError(e.to_string()))?;
+
+        let settings =
+            load_settings().map_err(|e| Error::BuildError(e.to_string()))?;
+        let game_client_path = settings
+            .game_client_path
+            .ok_or(Error::NullError("game_client_path".to_string()))?;
+
+        let package_path = game_client_path.join("res/packages/");
+        let archive_list = read_dir(package_path)
+            .map_err(|e| Error::BuildError(e.to_string()))?;
+
+        let pattern = Regex::new(r"^.*gui-part[0-9].pkg?")?;
+        for archive in archive_list.flatten() {
+            let dir_item_path = archive.path();
+            let str = dir_item_path.to_str().ok_or(Error::BuildError(
+                "failed to convert path to string".to_string(),
+            ))?;
+            if pattern.is_match(str) {
+                extract_archive(&dir_item_path, &tmp_dir.path().to_path_buf())
+                    .map_err(|e| Error::BuildError(e.to_string()))?;
+            }
+        }
+
+        let inside_archive_path =
+            tmp_dir.path().to_path_buf().join("gui/flash/swc/");
+        copy_directory(&inside_archive_path, &self.game_flash_lib)
+            .map_err(|e| Error::BuildError(e.to_string()))?;
+
+        tmp_dir.close().ok();
+        Ok(())
+    }
+}
+
+pub fn build_flash_client_lib(
+    wg_mod_home: &PathBuf,
+) -> Result<GameFlashLib, Error> {
+    let game_flash_lib_path = wg_mod_home.join("flash_lib");
+    let game_flash_lib = GameFlashLib::from(game_flash_lib_path);
+
+    if game_flash_lib.game_flash_lib.exists() {
+        remove_dir_all(&game_flash_lib.game_flash_lib)
+            .map_err(|e| Error::BuildError(e.to_string()))?;
+    }
+
+    create_dir_all(&game_flash_lib.game_flash_lib)
+        .map_err(|e| Error::BuildError(e.to_string()))?;
+
+    game_flash_lib
+        .build()
+        .map_err(|e| Error::BuildError(e.to_string()))?;
+
+    Ok(game_flash_lib)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_flash_archive_path() {
+        let tmp_dir = tempdir().unwrap();
+
+        let game_client_lib_path =
+            GameFlashLib::from(tmp_dir.path().to_path_buf());
+
+        let flash_file_path = game_client_lib_path.get_flash_archive_path(
+            &tmp_dir.path().to_path_buf(),
+            "1".to_string(),
+        );
+
+        assert_eq!(
+            flash_file_path,
+            tmp_dir
+                .path()
+                .to_path_buf()
+                .join("res/packages/gui-part1.pkg")
+        );
+    }
+}

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,5 +1,5 @@
+pub mod flash_lib;
 mod python;
-
 use crate::builder::python::PythonBuilder;
 use crate::config::mod_conf;
 use crate::config::mod_conf::ModConf;

--- a/src/config/asconfig_json.rs
+++ b/src/config/asconfig_json.rs
@@ -1,0 +1,38 @@
+use crate::config::mod_conf::ModConf;
+use serde_derive::{Deserialize, Serialize};
+use std::io;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AsconfigcJson {
+    #[serde(rename = "config")]
+    pub config: String,
+    #[serde(rename = "compilerOptions")]
+    pub compiler_option: CompilerOption,
+    #[serde(rename = "mainClass")]
+    pub main_class: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CompilerOption {
+    #[serde(rename = "output")]
+    pub output: String,
+    #[serde(rename = "source-path")]
+    pub source_path: Vec<String>,
+}
+
+impl AsconfigcJson {
+    pub fn write_json_to_file(
+        &self, file_path: &PathBuf,
+    ) -> Result<(), io::Error> {
+        let file = std::fs::File::create(file_path)?;
+
+        serde_json::to_writer_pretty(file, self)?;
+        Ok(())
+    }
+
+    pub fn from_file(filename: &PathBuf) -> Result<AsconfigcJson, io::Error> {
+        let file = std::fs::File::open(filename)?;
+        Ok(serde_json::from_reader(file)?)
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
+pub mod asconfig_json;
 pub mod mod_conf;
 pub mod settings;
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,4 +1,6 @@
 use crate::config;
+use crate::config::get_tool_home;
+use crate::config::settings::Error::LoadError;
 use crate::utils::convert_pathbuf_to_string::Stringify;
 use serde_derive::{Deserialize, Serialize};
 use std::env;
@@ -12,6 +14,8 @@ pub enum Error {
     FileError(#[from] std::io::Error),
     #[error("Failed to read json : {0}")]
     ParsingError(String),
+    #[error("Failed to load settings : {0}")]
+    LoadError(String),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -104,4 +108,12 @@ impl Settings {
         settings.settings_file_path = filename.clone();
         Ok(settings)
     }
+}
+
+pub fn load_settings() -> Result<Settings, Error> {
+    let wg_mod_home = get_tool_home().map_err(|e| LoadError(e.to_string()))?;
+    let settings = Settings::from_json_file(&wg_mod_home.join("settings.json"))
+        .map_err(|e| LoadError(e.to_string()))?;
+
+    Ok(settings)
 }

--- a/src/new/template.rs
+++ b/src/new/template.rs
@@ -1,4 +1,5 @@
 use super::NewArgs;
+use crate::config::asconfig_json::{AsconfigcJson, CompilerOption};
 use crate::config::mod_conf::ModConf;
 use crate::utils::convert_to_absolute_path::convert_to_absolute_path;
 use crate::utils::file_template;
@@ -87,26 +88,22 @@ fn template_ui_entrypoint(args: &NewArgs, parent_dir: &PathBuf) -> Result<()> {
 }
 
 fn template_ui_config(args: &NewArgs, parent_dir: &PathBuf) -> Result<()> {
-    write_template(
-        parent_dir,
-        "asconfig.json",
-        "{
-  \"config\": \"flex\",
-  \"type\": \"lib\",
-  \"compilerOptions\": {
-    \"output\": \".\",
-    \"targets\": [
-      \"SWF\"
-    ],
-    \"source-map\": true
-  },
-  \"mainClass\": \"{{main_class_name}}\"
-}
-",
-        &json!({
-            "main_class_name": args.name.to_case(Case::Pascal),
-        }),
-    )
+    fs::create_dir_all(parent_dir)
+        .map_err(file_template::Error::DirectoryCreateError)?;
+    let ui_config = AsconfigcJson {
+        config: "flex".to_string(),
+        compiler_option: CompilerOption {
+            output: "".to_string(),
+            source_path: vec![],
+        },
+        main_class: "".to_string(),
+    };
+
+    let filename = parent_dir.join("asconfigc.json");
+
+    Ok(ui_config
+        .write_json_to_file(&filename)
+        .map_err(|e| file_template::Error::FileCreateError(e, filename))?)
 }
 
 fn init_git_repository(directory: &PathBuf) -> Result<()> {

--- a/src/new/tests.rs
+++ b/src/new/tests.rs
@@ -65,22 +65,17 @@ def fini():
         );
 
         let ui_config_content =
-            read_to_string(mod_path.join("ui/asconfig.json")).unwrap();
+            read_to_string(mod_path.join("ui/asconfigc.json")).unwrap();
         assert_eq!(
             ui_config_content,
             "{
   \"config\": \"flex\",
-  \"type\": \"lib\",
   \"compilerOptions\": {
-    \"output\": \".\",
-    \"targets\": [
-      \"SWF\"
-    ],
-    \"source-map\": true
+    \"output\": \"\",
+    \"source-path\": []
   },
-  \"mainClass\": \"BetterMatchmaking\"
-}
-"
+  \"mainClass\": \"\"
+}"
         );
 
         template_nvm_config(&mod_path).unwrap();

--- a/src/utils/extract_archive.rs
+++ b/src/utils/extract_archive.rs
@@ -1,0 +1,66 @@
+use crate::builder::flash_lib::GameFlashLib;
+use crate::utils::copy_directory::copy_directory;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use tempfile::tempdir;
+use zip::result::ZipError;
+use zip::write::{ExtendedFileOptions, FileOptions};
+use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Archive does not exist: {0}")]
+    ArchiveError(String),
+    #[error("Failed to extract archive: {0}")]
+    UnzipError(#[from] ZipError),
+}
+
+pub fn extract_archive(
+    archive_path: &PathBuf, destination: &PathBuf,
+) -> Result<(), Error> {
+    let file = File::open(&archive_path)
+        .map_err(|e| Error::ArchiveError(e.to_string()))?;
+
+    let mut archive = ZipArchive::new(file)?;
+    archive.extract(destination)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+
+    fn extract_archive_test() {
+        let tmp_dir = tempdir().unwrap();
+
+        mock_archive(
+            &tmp_dir.path().to_path_buf(),
+            "build_test.zip".to_string(),
+        );
+
+        extract_archive(
+            &tmp_dir.path().to_path_buf().join("build_test.zip"),
+            &tmp_dir.path().to_path_buf(),
+        )
+        .unwrap();
+
+        assert!(tmp_dir.path().join("build_test.txt").exists());
+        tmp_dir.close().unwrap();
+    }
+}
+
+fn mock_archive(path: &PathBuf, archive_name: String) {
+    let file = File::create(path.join(archive_name)).unwrap();
+    let writer = BufWriter::new(file);
+    let mut zip = ZipWriter::new(writer);
+    let options: FileOptions<'_, ExtendedFileOptions> =
+        FileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("build_test.txt", options).unwrap();
+    zip.write_all(b"Hello, world!").unwrap();
+
+    zip.finish().unwrap();
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod convert_pathbuf_to_string;
 pub mod convert_to_absolute_path;
 pub mod copy_directory;
 pub mod downloader;
+pub mod extract_archive;
 pub mod file_template;
 pub mod pattern_validator;
 


### PR DESCRIPTION
### Goal: 
- Get SWC file needed to complile flash 

### Done: 
- Add flash game lib builder 
-> get the archive containing SWC file, unzip them and put it in .wg-mod/flash_lib

### To_test:
Feature is not actually executed. it will be during flash build 
If you want to test, you will have to add this line: 
`config/mod.rs -> Configs::load() `
in file:
`build_flash_client_lib(&wg_mod_home)?;`

### Question : 
- When do we launch the build ?
only on flash build ? all the time on execution(if the directory don't already exist) ? other better idea ?

### TODO:
- manage error case when the `game_client` directory (in settings) exist but not contain the wot-client ( [Corresponding  #issue](https://github.com/gabrielhamel/wg-mod/issues/42)) : 

In that case the settings will be created because directory exist and the builder throw an error because archive are not found.
the problem is that the user can't change game_client_path settings without knowing the utils and delete the file `.../.wg-mod/settings.json`
SOLUTION: add a CLI command to change the game_client_path settings and put a message explaining that instead of throwing error